### PR TITLE
Update messages_zh_CN.properties

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/messages_zh_CN.properties
+++ b/modules/gui/src/com/haulmont/cuba/gui/messages_zh_CN.properties
@@ -909,6 +909,7 @@ table.rowsCount.msg1=%s 行/
 table.rowsCount.msg2Plural1 = %s 行
 table.rowsCount.msg2Plural2 = %s 行
 table.rowsCount.msg2Singular = %s 行
+table.rowsCount.msg2Singular1 = %s 行
 table.rowsCount.msg3=[?]
 table.showInfoAction = 系统信息
 table.showInfoAction.createTs = 创建时间


### PR DESCRIPTION
解决 只有一行数据时显示成 `table.rowsCount.msg2Singular1` 的问题