### PR TITLE
修复过滤器刷新按钮国际化错误

### DIFF
--- a/modules/gui/src/com/haulmont/cuba/gui/messages_zh_CN.properties
+++ b/modules/gui/src/com/haulmont/cuba/gui/messages_zh_CN.properties
@@ -794,6 +794,7 @@ filter.saveFilter.suchNameAlreadyExists=该名称的过滤器已存在
 filter.saveWithValues=带值保存
 filter.search = 搜索
 filter.searchBtn.description=Shift-Enter
+filter.searchBtn.applyImmediately.caption=刷新
 filter.setPrefix=集合
 filter.showMore = <所有过滤器 (%s)>
 folders.appFoldersRoot = 应用程序文件夹


### PR DESCRIPTION
在modules/gui/src/com/haulmont/cuba/gui/messages_zh_CN.properties增加filter.searchBtn.applyImmediately.caption=刷新